### PR TITLE
Unpin python-keycloak

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    python-keycloak == 1.4.0
+    python-keycloak
     flask >= 2.2.3,<3.0
     fastapi>=0.85.0,<1.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    python-keycloak
+    python-keycloak >= 1,<4.0
     flask >= 2.2.3,<3.0
     fastapi>=0.85.0,<1.0
 


### PR DESCRIPTION
Previously, python-keycloak was set to == 1.7.0. Currently, the latest verison is 3.7.0. For backwards compatability, I just removed the versioning and hence keep it open to the pip context. 