### PR TITLE
v2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
             - name: Install package
               run: |
-                  python -m pip install .[pre_commit]
+                  python -m pip install .[dev]
 
             - name: Run pre-commit
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,14 @@ jobs:
               uses: actions/setup-python@v3
               with:
                   python-version: '3.10'
-            - uses: pre-commit/action@v2.0.0
+
+            - name: Install package
+              run: |
+                  python -m pip install .[pre_commit]
+
+            - name: Run pre-commit
+              run: |
+                  pre-commit run --all-files
 
     test-package:
 
@@ -33,15 +40,14 @@ jobs:
 
             - uses: actions/checkout@v3
 
-            - uses: actions/setup-python@v6
+            - uses: actions/setup-python@v3
               with:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install package
               run: |
-                  python -m pip install  .
+                  python -m pip install .[tests]
 
             - name: Run tests
               run: |
-                  python -m pip install .[tests]
                   python -m pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
             - uses: actions/checkout@v3
 
-            - uses: actions/setup-python@v3
+            - uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ In order to successfully enable the callback for the token-generation and token-
 | `KEYCLOAK_VERIFY_HOST`          | Controls whether SSL certificates are verified for HTTPS requests. Default is set to `False`.              | "True"                                 |
 | `KEYCLOAK_REALM_ADMIN_USER`     | User name of the realm admin, if any action shall be performed as admin in your Flask/FastAPI application. | "admin"                                |
 | `KEYCLOAK_REALM_ADMIN_PASSWORD` | Password of the realm admin, if any action shall be performed as admin in your Flask/FastAPI application.  | "admin_password"                       |
+| `KEYCLOAK_USE_SERVICE_ACCOUNT`  | Whether a service account shall be used for admin operations instead of a custom user account with `KEYCLOAK_REALM_ADMIN_USER` and `KEYCLOAK_REALM_ADMIN_PASSWORD`. A service account in Keycloak is a special client configuration that allows applications to authenticate directly using client credentials (client ID and secret) without requiring a user login, enabling secure machine-to-machine (like a microservice, script, or backend job) API access. For more details, see the [official Keycloak documentation on service account authentication](https://www.keycloak.org/docs/latest/server_development/index.html#authenticating-with-a-service-account).  | "True"  |
 | `SKIP_ENV_CHECK`                | Optional. If set, skips the check for mandatory environment variables during startup.                      | "True"                                    |
 
 #### Note

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
 dev =
     bumpver==2021.1114
     dunamai==1.7.0
-    pre-commit~=2.20.0
+    pre-commit~=4.3.0
 tests =
     pytest>=7.1.3,<8.0
     requests-mock>=1.10.0,<2.0

--- a/shieldapi/keycloak_utils.py
+++ b/shieldapi/keycloak_utils.py
@@ -79,8 +79,11 @@ def get_keycloak_admin(
     server_url: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
     realm_name: Optional[str] = None,
     verify: Optional[bool] = None,
+    use_service_account: Optional[bool] = None,
 ) -> KeycloakAdmin:
     """Create and return a KeycloakAdmin object with the provided credentials.
 
@@ -89,14 +92,26 @@ def get_keycloak_admin(
             The URL of the Keycloak server. If missing, $KEYCLOAK_HOST or 'http://keycloak:8080/auth/' will be used.
         username (Optional[str]):
             The username to log in with. If missing, $KEYCLOAK_REALM_ADMIN_USER will be used.
+            Only used when use_service_account is False.
         password (Optional[str]):
             The password to log in with. If missing, $KEYCLOAK_REALM_ADMIN_PASSWORD will be used.
+            Only used when use_service_account is False.
+        client_id (Optional[str]):
+            The client ID for service account authentication. If missing, $KEYCLOAK_CLIENT_ID will be used.
+            Only used when use_service_account is True.
+        client_secret (Optional[str]):
+            The client secret for service account authentication. If missing, $KEYCLOAK_CLIENT_SECRET will be used.
+            Only used when use_service_account is True.
         realm_name (Optional[str]):
             The name of the realm in Keycloak. If missing, $KEYCLOAK_REALM_NAME will be used.
         verify (Optional[bool]):
             Controls whether SSL certificates are verified for HTTPS requests. If set to False, SSL
             verification is disabled. If set to a string, it should be the path to a CA_BUNDLE file or
             a directory containing certificates of trusted CA.
+        use_service_account (Optional[bool]):
+            Whether to use service account authentication (client_id/client_secret) instead of user
+            authentication (username/password). If missing, $KEYCLOAK_USE_SERVICE_ACCOUNT will be used,
+            defaults to False.
 
     Returns:
         KeycloakAdmin:
@@ -107,15 +122,32 @@ def get_keycloak_admin(
             If any required values are missing.
     """
     logger.debug("Creating KeycloakAdmin instance")
-    return KeycloakAdmin(
-        server_url=_get_value(
-            server_url, "KEYCLOAK_HOST", "http://keycloak:8080/auth/"
-        ),
-        username=_get_value(username, "KEYCLOAK_REALM_ADMIN_USER"),
-        password=_get_value(password, "KEYCLOAK_REALM_ADMIN_PASSWORD"),
-        realm_name=_get_value(realm_name, "KEYCLOAK_REALM_NAME"),
-        verify=_get_value(verify, "KEYCLOAK_VERIFY_HOST", False, True),
+    use_service_account = _get_value(
+        use_service_account, "KEYCLOAK_USE_SERVICE_ACCOUNT", False, True
     )
+    if use_service_account:
+        logger.debug("Using Service Account for Admin authentication")
+        admin = KeycloakAdmin(
+            server_url=_get_value(
+                server_url, "KEYCLOAK_HOST", "http://keycloak:8080/auth/"
+            ),
+            client_id=_get_value(client_id, "KEYCLOAK_CLIENT_ID"),
+            client_secret_key=_get_value(client_secret, "KEYCLOAK_CLIENT_SECRET"),
+            realm_name=_get_value(realm_name, "KEYCLOAK_REALM_NAME"),
+            verify=_get_value(verify, "KEYCLOAK_VERIFY_HOST", False, True),
+        )
+    else:
+        logger.debug("Using Custom User Account for Admin authentication")
+        admin = KeycloakAdmin(
+            server_url=_get_value(
+                server_url, "KEYCLOAK_HOST", "http://keycloak:8080/auth/"
+            ),
+            username=_get_value(username, "KEYCLOAK_REALM_ADMIN_USER"),
+            password=_get_value(password, "KEYCLOAK_REALM_ADMIN_PASSWORD"),
+            realm_name=_get_value(realm_name, "KEYCLOAK_REALM_NAME"),
+            verify=_get_value(verify, "KEYCLOAK_VERIFY_HOST", False, True),
+        )
+    return admin
 
 
 def _get_value(

--- a/shieldapi/keycloak_utils.py
+++ b/shieldapi/keycloak_utils.py
@@ -110,8 +110,13 @@ def get_keycloak_admin(
             a directory containing certificates of trusted CA.
         use_service_account (Optional[bool]):
             Whether to use service account authentication (client_id/client_secret) instead of user
-            authentication (username/password). If missing, $KEYCLOAK_USE_SERVICE_ACCOUNT will be used,
-            defaults to False.
+            authentication (username/password). A service account in Keycloak is a special client configuration
+            that allows applications to authenticate directly using client credentials
+            (client ID and secret) without requiring a user login, enabling secure machine-to-machine
+            (like a microservice, script, or backend job) API access.
+            If missing, $KEYCLOAK_USE_SERVICE_ACCOUNT will be used, defaults to False.
+            See also:
+            https://www.keycloak.org/docs/latest/server_development/index.html#authenticating-with-a-service-account
 
     Returns:
         KeycloakAdmin:

--- a/tests/test_keycloak_utils.py
+++ b/tests/test_keycloak_utils.py
@@ -2,7 +2,6 @@
 
 import os
 import warnings
-from ast import literal_eval
 from typing import Any, Dict, List, Optional
 
 import pytest


### PR DESCRIPTION
Add capabilities for the service account of a realm when authenticating as administrator.

This will be enabled by simply providing the `client_id` and the `client_secret` to the `get_keycloak_admin`-utility when instanciating the `KeycloakAdmin`-object.

In order to simply switch from custom admin account to the service account, one can simply set the `KEYCLOAK_USE_SERVICE_ACCOUNT` env variable without unassigning existing variables like `KEYCLOAK_REALM_ADMIN_USER` and `KEYCLOAK_REALM_ADMIN_PASSWORD`. 

