### PR TITLE
Maintenance v2.2.0: fix role check, dep cleanup, test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
             - name: Install package
               run: |
-                  python -m pip install .[tests]
+                  python -m pip install ".[tests,flask,fastapi]"
 
             - name: Run tests
               run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
 
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v5.0.0
+      rev: v6.0.0
       hooks:
           - id: check-json
           - id: check-yaml
@@ -12,13 +12,13 @@ repos:
           - id: end-of-file-fixer
           - id: trailing-whitespace
 
-    - repo: https://github.com/psf/black
-      rev: 24.10.0
+    - repo: https://github.com/psf/black-pre-commit-mirror
+      rev: 26.5.1
       hooks:
           - id: black
 
     - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
+      rev: 8.0.1
       hooks:
           - id: isort
             args: [--profile, black, --filter-files]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = shieldapi
-version = v2.1.0
+version = v2.2.0
 author = SINTEF, Fraunhofer IWM
 author_email = yoav.nahshon@iwm.fraunhofer.de
 description = A package for endpoint protection of APIs using Keycloak
@@ -13,26 +13,28 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
-    python-keycloak>=1
-    flask>=2.2.3,<3.0
-    fastapi>=0.85.0,<1.0
+    python-keycloak>=4.0
 
 [options.extras_require]
+flask =
+    flask>=2.3
+fastapi =
+    fastapi>=0.100.0
 dev =
-    bumpver==2021.1114
-    dunamai==1.7.0
+    bumpver>=2023.1119
+    dunamai>=1.7.0
     pre-commit~=4.3.0
 tests =
-    pytest>=7.1.3,<8.0
+    pytest>=7.1.3
     requests-mock>=1.10.0,<2.0
-    httpx>=0.23.3,<1.0
+    httpx>=0.23.3
     semver>=2.13.0,<3.0
     pytest-mock>=3.10.0
 
 [bumpver]
-current_version = "v0.0.0"
+current_version = "v2.2.0"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True

--- a/shieldapi/frameworks/fastapi.py
+++ b/shieldapi/frameworks/fastapi.py
@@ -104,7 +104,7 @@ class BasicLoginCredentials(HTTPBasicCredentials):
             f"BasicLoginCredentials.token: Attempting login for username={self.username}"
         )
         token = login(self.username, self.password)
-        if len(token) == 2:
+        if isinstance(token, tuple):
             logger.error(
                 f"BasicLoginCredentials.token: Invalid credentials for username={self.username}"
             )
@@ -154,7 +154,7 @@ class BasicLogin(HTTPBasic):
             f"BasicLogin.__call__: Credentials extracted for username={log.username}"
         )
         token = login(log.username, log.password)
-        if len(token) == 2:
+        if isinstance(token, tuple):
             logger.error(
                 f"BasicLogin.__call__: Invalid credentials for username={log.username}"
             )

--- a/shieldapi/frameworks/flask.py
+++ b/shieldapi/frameworks/flask.py
@@ -1,4 +1,4 @@
-"""Functions and decorators for shieldapi in Flask."""
+"""Decorators for protecting Flask endpoints with Keycloak authentication."""
 
 from functools import wraps
 from typing import Callable, List
@@ -13,13 +13,10 @@ from shieldapi.keycloak_utils import (
 )
 
 
-def get_access_token():
-    """
-    Returns the access token from the Authorization header of the request.
+def get_access_token() -> str:
+    """Extract the Bearer token from the Authorization request header.
 
-    Returns:
-        str:
-            The access token.
+    Returns an empty string when the header is missing or malformed.
     """
     auth_header = request.headers.get("Authorization", default="")
     if not auth_header or "Bearer" not in auth_header:
@@ -31,17 +28,7 @@ def get_access_token():
 
 
 def login_required(fn: Callable) -> Callable:
-    """
-    Decorator that checks if the user is logged in.
-
-    Args:
-        fn (Callable):
-            The function to be decorated.
-
-    Returns:
-        Callable:
-            The decorated function.
-    """
+    """Decorator: reject requests without a valid Keycloak Bearer token (401)."""
 
     @wraps(fn)
     def decorated_view(*args, **kwargs):
@@ -50,8 +37,7 @@ def login_required(fn: Callable) -> Callable:
             logger.warning("login_required: Access token is missing")
             abort(401)
 
-        valid = check_token_validity(access_token)
-        if not valid:
+        if not check_token_validity(access_token):
             logger.warning("login_required: Access token is invalid or expired")
             abort(401)
 
@@ -62,16 +48,11 @@ def login_required(fn: Callable) -> Callable:
 
 
 def admin_required(fn: Callable) -> Callable:
-    """
-    Decorator that checks if the user is an admin.
+    """Decorator: reject requests where the token does not carry the 'admin' role (403).
 
-    Args:
-        fn (Callable):
-            The function to be decorated.
-
-    Returns:
-        Callable:
-            The decorated function.
+    Checks realm_access.roles, resource_access.<client>.roles, and any flat
+    top-level 'roles' field in the Keycloak introspection response.
+    Must be stacked inside login_required so the token is already validated.
     """
 
     @wraps(fn)
@@ -92,16 +73,14 @@ def admin_required(fn: Callable) -> Callable:
 
 
 def role_required(role: str) -> Callable:
-    """
-    Decorator that limits access to users with a certain role.
+    """Decorator factory: reject requests missing the given Keycloak role (403).
+
+    Checks realm_access.roles, resource_access.<client>.roles, and any flat
+    top-level 'roles' field in the Keycloak introspection response.
+    Must be stacked inside login_required so the token is already validated.
 
     Args:
-        role (str):
-            The required role.
-
-    Returns:
-        Callable:
-            The decorator function.
+        role: The Keycloak role name that the caller must hold.
     """
 
     def decorator(f: Callable) -> Callable:
@@ -110,20 +89,18 @@ def role_required(role: str) -> Callable:
             access_token = get_access_token()
             if not access_token:
                 logger.warning(
-                    f"role_required: Access token is missing for role {role}"
+                    f"role_required: Access token is missing for role '{role}'"
                 )
                 abort(401)
 
             if not check_role(access_token, role):
                 logger.warning(
-                    f"role_required: User does not have required role {role}"
+                    f"role_required: User does not have required role '{role}'"
                 )
                 abort(403)
 
-            logger.info(f"role_required: User has required role {role}")
-            res = f(*args, **kwargs)
-
-            return res
+            logger.info(f"role_required: User has required role '{role}'")
+            return f(*args, **kwargs)
 
         return restricted_function
 
@@ -131,17 +108,10 @@ def role_required(role: str) -> Callable:
 
 
 def has_scope(scope_list: List[str]) -> Callable:
-    """
-    Decorator that limits access to the applications which have been
-    granted the required scopes.
+    """Decorator factory: reject requests where the token lacks any listed OAuth scope (403).
 
     Args:
-        scope_list (List[str]):
-            The list of required scopes.
-
-    Returns:
-        Callable:
-            The decorator function.
+        scope_list: OAuth scopes that must all be present in the token.
     """
 
     def decorator(f: Callable) -> Callable:
@@ -150,25 +120,23 @@ def has_scope(scope_list: List[str]) -> Callable:
             token = get_access_token()
             if not token:
                 logger.warning("has_scope: Access token is missing")
-                return None
+                abort(401)
 
             token_info = get_keycloak_openid().introspect(token)
-            if not token_info.json()["active"]:
+            if not bool(token_info.get("active")):
                 logger.warning("has_scope: Access token is inactive")
-                return None
+                abort(401)
 
-            granted_scope = token_info.json()["scope"].split()
+            granted_scope = token_info.get("scope", "").split()
             for requested_scope in scope_list:
                 if requested_scope not in granted_scope:
                     logger.warning(
-                        f"has_scope: Required scope {requested_scope} not granted"
+                        f"has_scope: Required scope '{requested_scope}' not granted"
                     )
-                    return None
+                    abort(403)
 
             logger.info("has_scope: All required scopes are granted")
-            res = f(*args, **kwargs)
-
-            return res
+            return f(*args, **kwargs)
 
         return restricted_function
 

--- a/shieldapi/keycloak_utils.py
+++ b/shieldapi/keycloak_utils.py
@@ -3,7 +3,7 @@
 import os
 import warnings
 from ast import literal_eval
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from keycloak import KeycloakAdmin, KeycloakOpenID
 
@@ -40,28 +40,14 @@ def get_keycloak_openid(
     client_secret: Optional[str] = None,
     verify: Optional[bool] = None,
 ) -> KeycloakOpenID:
-    """
-    Creates a KeycloakOpenID instance using the provided parameters or environment variables.
+    """Create a KeycloakOpenID instance from parameters or environment variables.
 
     Kwargs:
-        server_url (Optional[str]):
-            The URL of the Keycloak server. If missing, $KEYCLOAK_HOST  or 'http://keycloak:8080/auth/' will be used.
-        realm_name (Optional[str]):
-            The name of the realm in Keycloak. If missing, $KEYCLOAK_REALM_NAME will be used.
-        client_id (Optional[str]):
-            The id of the client in Keycloak. If missing, $KEYCLOAK_CLIENT_ID or 'shieldapi' will be used.
-        client_secret (Optional[str]):
-            The client secret key for the client in Keycloak. If missing, $KEYCLOAK_CLIENT_SECRET will be used.
-        verify (Optional[bool]):
-            Controls whether SSL certificates are verified for HTTPS requests. If set to False, SSL
-            verification is disabled. If set to a string, it should be the path to a CA_BUNDLE file or
-            a directory containing certificates of trusted CA.
-
-    Returns:
-        KeycloakOpenID: An object for communicating with Keycloak via OpenID Connect.
-
-    Raises:
-        KeyError: If any required values are missing.
+        server_url: Keycloak server URL. Falls back to $KEYCLOAK_HOST.
+        realm_name: Realm name. Falls back to $KEYCLOAK_REALM_NAME.
+        client_id: OIDC client ID. Falls back to $KEYCLOAK_CLIENT_ID.
+        client_secret: Client secret. Falls back to $KEYCLOAK_CLIENT_SECRET.
+        verify: TLS verification. Falls back to $KEYCLOAK_VERIFY_HOST (default False).
     """
     logger.debug("Creating KeycloakOpenID instance")
     return KeycloakOpenID(
@@ -85,46 +71,18 @@ def get_keycloak_admin(
     verify: Optional[bool] = None,
     use_service_account: Optional[bool] = None,
 ) -> KeycloakAdmin:
-    """Create and return a KeycloakAdmin object with the provided credentials.
+    """Create a KeycloakAdmin instance from parameters or environment variables.
 
     Kwargs:
-        server_url (Optional[str]):
-            The URL of the Keycloak server. If missing, $KEYCLOAK_HOST or 'http://keycloak:8080/auth/' will be used.
-        username (Optional[str]):
-            The username to log in with. If missing, $KEYCLOAK_REALM_ADMIN_USER will be used.
-            Only used when use_service_account is False.
-        password (Optional[str]):
-            The password to log in with. If missing, $KEYCLOAK_REALM_ADMIN_PASSWORD will be used.
-            Only used when use_service_account is False.
-        client_id (Optional[str]):
-            The client ID for service account authentication. If missing, $KEYCLOAK_CLIENT_ID will be used.
-            Only used when use_service_account is True.
-        client_secret (Optional[str]):
-            The client secret for service account authentication. If missing, $KEYCLOAK_CLIENT_SECRET will be used.
-            Only used when use_service_account is True.
-        realm_name (Optional[str]):
-            The name of the realm in Keycloak. If missing, $KEYCLOAK_REALM_NAME will be used.
-        verify (Optional[bool]):
-            Controls whether SSL certificates are verified for HTTPS requests. If set to False, SSL
-            verification is disabled. If set to a string, it should be the path to a CA_BUNDLE file or
-            a directory containing certificates of trusted CA.
-        use_service_account (Optional[bool]):
-            Whether to use service account authentication (client_id/client_secret) instead of user
-            authentication (username/password). A service account in Keycloak is a special client configuration
-            that allows applications to authenticate directly using client credentials
-            (client ID and secret) without requiring a user login, enabling secure machine-to-machine
-            (like a microservice, script, or backend job) API access.
-            If missing, $KEYCLOAK_USE_SERVICE_ACCOUNT will be used, defaults to False.
-            See also:
-            https://www.keycloak.org/docs/latest/server_development/index.html#authenticating-with-a-service-account
-
-    Returns:
-        KeycloakAdmin:
-            An object with the provided credentials.
-
-    Raises:
-        KeyError:
-            If any required values are missing.
+        server_url: Keycloak server URL. Falls back to $KEYCLOAK_HOST.
+        username: Admin username. Falls back to $KEYCLOAK_REALM_ADMIN_USER.
+        password: Admin password. Falls back to $KEYCLOAK_REALM_ADMIN_PASSWORD.
+        client_id: Client ID for service account auth. Falls back to $KEYCLOAK_CLIENT_ID.
+        client_secret: Client secret for service account auth. Falls back to $KEYCLOAK_CLIENT_SECRET.
+        realm_name: Realm name. Falls back to $KEYCLOAK_REALM_NAME.
+        verify: TLS verification. Falls back to $KEYCLOAK_VERIFY_HOST (default False).
+        use_service_account: Use client credentials instead of user/password.
+            Falls back to $KEYCLOAK_USE_SERVICE_ACCOUNT (default False).
     """
     logger.debug("Creating KeycloakAdmin instance")
     use_service_account = _get_value(
@@ -161,38 +119,26 @@ def _get_value(
     default: Optional[Any] = None,
     boolean: Optional[bool] = False,
 ) -> Any:
-    """Get a value by following the assignment priority.
+    """Return param, falling back to env_var, then default.
 
-    Parameters take priority over environment variables and defaults.
-    An error is raised if no values are defined.
-
-    Args:
-        var (Any):
-            parameter passed to the respective upstream function.
-        env_var (str):
-            Name of the corresponding environmental variable.
-        default (Optional[Any]):
-            Default value when no others are provided
-        boolean (Optional[bool]):
-            Whether the expected values is a boolean
-    Returns:
-        Any: The value of the Python-object (preferred) or its respective env-variable.
-        The latter can also resolve into a `None`, if not set.
-
-    Raises:
-       UserWarning: If both the parameter and env-variable are set.
-       ValueError: If both the parameter and env-variable are None, or a boolean
+    Emits a UserWarning when both param and env_var are set (param wins).
+    Raises ValueError when all three are None.
+    Raises TypeError when boolean=True and the env_var value is not 'True'/'False'.
     """
     env = os.environ.get(env_var)
 
     if (param or isinstance(param, bool)) and env:
-        message = f"""Both the kwarg ({param}) and the env-variable for '{env_var}' ({env}) are assigned.
-        Note that the argument takes precedence over the env-variable."""
+        message = (
+            f"Both the kwarg ({param}) and the env-variable for '{env_var}' ({env}) are assigned. "
+            f"Note that the argument takes precedence over the env-variable."
+        )
         warnings.warn(UserWarning(message))
         logger.warning(message)
     elif param is None and env is None and default is None:
-        message = f"""Both the kwarg and the env-variable for '{env_var}' are None.
-        Please assign one of them to a value."""
+        message = (
+            f"Both the kwarg and the env-variable for '{env_var}' are None. "
+            f"Please assign one of them to a value."
+        )
         logger.error(message)
         raise ValueError(message)
 
@@ -215,37 +161,55 @@ def _get_value(
 
 
 def check_role(token: str, role: str) -> bool:
-    """Check if a token contains a certain role
+    """Return True if the token grants the given role.
+
+    Keycloak's token introspection endpoint returns roles in two locations:
+    - realm_access.roles  (realm-level roles)
+    - resource_access.<client>.roles  (client-level roles)
+
+    A flat top-level ``roles`` field is also checked for compatibility with
+    Keycloak deployments that include a custom protocol mapper.
 
     Args:
-        token (str): token from a user
-        role (str): role to be checked
-
-    Returns:
-        bool: whether the token contains the role
+        token: Raw access token string.
+        role: Role name to check.
     """
     logger.info(f"Checking role '{role}' for token")
     token_info = get_keycloak_openid().introspect(token)
-    if bool(token_info["active"]):
-        has_role = "roles" in token_info and role in token_info["roles"]
-        logger.debug(f"Token has role '{role}': {has_role}")
-        return has_role
+    if not bool(token_info.get("active")):
+        logger.debug("Token is inactive")
+        return False
+
+    # Flat roles field (custom protocol mapper or older Keycloak configs)
+    if role in token_info.get("roles", []):
+        logger.debug(f"Role '{role}' found in flat roles field")
+        return True
+
+    # Realm-level roles
+    if role in token_info.get("realm_access", {}).get("roles", []):
+        logger.debug(f"Role '{role}' found in realm_access.roles")
+        return True
+
+    # Client-level roles across all resource_access entries
+    for client, client_data in token_info.get("resource_access", {}).items():
+        if role in client_data.get("roles", []):
+            logger.debug(f"Role '{role}' found in resource_access.{client}.roles")
+            return True
+
+    logger.debug(f"Role '{role}' not found in token")
     return False
 
 
 def check_token_validity(
     access_token: str, validate_with_auth_server: Optional[bool] = True
 ) -> bool:
-    """Check if the given access token is valid.
+    """Return True if the access token is currently valid.
 
     Args:
-        access_token: str
-            The access token to check.
-        validate_with_auth_server: boolean
-            Indicates whether the validation is done through the server.
-
-    Returns:
-        bool: Whether the token is valid.
+        access_token: The access token to check.
+        validate_with_auth_server: When True (default), validates via Keycloak
+            introspection. When False, validates the JWT signature locally
+            (requires JWKS key configuration).
     """
     logger.info("Checking token validity")
     keycloak_openid = get_keycloak_openid()
@@ -253,13 +217,13 @@ def check_token_validity(
     valid = False
     if validate_with_auth_server:
         token_info = keycloak_openid.introspect(access_token)
-        valid = bool(token_info["active"])
+        valid = bool(token_info.get("active"))
     else:
         try:
             get_keycloak_openid().decode_token(access_token, validate=True)
             valid = True
         except Exception as e:
-            logger.warning(f"AuthTokenBearer.__call__: Token validation failed: {e}")
+            logger.warning(f"check_token_validity: Token validation failed: {e}")
     logger.debug(f"Token validity: {valid}")
     return valid
 
@@ -271,39 +235,18 @@ def check_useraccount_access(
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
     verify: Optional[bool] = None,
-) -> str:
-    """
-    Check if an access token has the 'openid' scope.
+) -> Tuple[str, int]:
+    """Return (message, status_code) indicating whether the token has 'openid' scope.
 
     Args:
-        access_token: str
-            The access token to check.
-    Kwargs:
-        server_url (Optional[str]):
-            The URL of the Keycloak server. If not provided, the value from the environment variable
-            KEYCLOAK_HOST will be used.
-        realm_name (Optional[str]):
-            The name of the realm in Keycloak. If not provided, the value from the environment variable
-            KEYCLOAK_REALM_NAME will be used.
-        client_id (Optional[str]):
-            The id of the client in Keycloak. If not provided, the value from the environment
-            variable KEYCLOAK_CLIENT_ID will be used.
-        client_secret (Optional[str]):
-            The client secret key for the client in Keycloak. If not provided, the value from the environment
-            variable KEYCLOAK_CLIENT_SECRET will be used.
-        verify (Optional[bool]):
-            Controls whether SSL certificates are verified for HTTPS requests. If set to False, SSL
-            verification is disabled. If set to a string, it should be the path to a CA_BUNDLE file or
-            a directory containing certificates of trusted CA.
-
-    Returns:
-        str: A string indicating whether or not the access token has the 'openid' scope.
+        access_token: The access token to check.
+    Kwargs: See get_keycloak_openid for remaining parameters.
     """
     logger.info("Checking user account access")
     token_info = get_keycloak_openid(
         server_url, realm_name, client_id, client_secret, verify
     ).introspect(access_token)
-    granted_scope = token_info.json()["scope"].split()
+    granted_scope = token_info.get("scope", "").split()
     if "openid" not in granted_scope:
         message = "OpenID scope was not granted"
         logger.warning(message)
@@ -321,50 +264,28 @@ def login(
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
     verify: Optional[bool] = None,
-) -> str:
-    """
-    Logs in the user with the given username and password and generates an access token.
+) -> Union[str, Tuple[int, str]]:
+    """Authenticate with Keycloak and return a Bearer token string.
+
+    Returns ``"Bearer <access_token>"`` on success, or ``(status_code, message)``
+    on failure.
 
     Args:
-        username (Optional[str]):
-            The username to authenticate with.
-        password (Optional[str]):
-            The password to authenticate with.
-    Kwargs:
-        server_url (Optional[str]):
-            The URL of the Keycloak server. If not provided, the value from the environment variable
-            KEYCLOAK_HOST will be used.
-        realm_name (Optional[str]):
-            The name of the realm in Keycloak. If not provided, the value from the environment variable
-            KEYCLOAK_REALM_NAME will be used.
-        client_id (Optional[str]):
-            The id of the client in Keycloak. If not provided, the value from the environment
-            variable KEYCLOAK_CLIENT_ID will be used.
-        client_secret (Optional[str]):
-            The client secret key for the client in Keycloak. If not provided, the value from the environment
-            variable KEYCLOAK_CLIENT_SECRET will be used.
-        verify (Optional[Union[bool, str]]):
-            Controls whether SSL certificates are verified for HTTPS requests. If set to False, SSL
-            verification is disabled. If set to a string, it should be the path to a CA_BUNDLE file or
-            a directory containing certificates of trusted CA.
-
-    Returns:
-        str:
-            If successful, returns a string representing the access token. Otherwise, returns
-            a tuple containing the status code and an error message.
+        username: Keycloak username.
+        password: Keycloak password.
+    Kwargs: See get_keycloak_openid for remaining parameters.
     """
     logger.info("Logging in user")
     token = get_keycloak_openid(
         server_url, realm_name, client_id, client_secret, verify
     ).token(username=username, password=password)
-    if not token.get("access_token") and token.get("token_type"):
+    if not token.get("access_token") or not token.get("token_type"):
         message = "Token could not be generated. Please contact the admin."
         logger.error(message)
         return 401, message
-    else:
-        token_str = f"{token.get('token_type')} {token.get('access_token')}"
-        logger.info("Token generated successfully")
-        return token_str
+    token_str = f"{token.get('token_type')} {token.get('access_token')}"
+    logger.info("Token generated successfully")
+    return token_str
 
 
 def make_auth_header(
@@ -375,38 +296,13 @@ def make_auth_header(
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
     verify: Optional[bool] = None,
-) -> Union[int, Tuple[int, str]]:
-    """
-    Logs into the Keycloak server and generates an access token using the given credentials.
+) -> Union[Dict[str, str], Tuple[int, str]]:
+    """Return an ``Authorization`` header dict, or ``(status_code, message)`` on failure.
 
     Args:
-        username (Optional[str]):
-            The username to authenticate with.
-        password (Optional[str]):
-            The password to authenticate with.
-    Kwargs:
-        server_url (Optional[str]):
-            The URL of the Keycloak server. If not provided, the value from the environment variable
-            KEYCLOAK_HOST will be used.
-        realm_name (Optional[str]):
-            The name of the realm in Keycloak. If not provided, the value from the environment variable
-            KEYCLOAK_REALM_NAME will be used.
-        client_id (Optional[str]):
-            The id of the client in Keycloak. If not provided, the value from the environment
-            variable KEYCLOAK_CLIENT_ID will be used.
-        client_secret (Optional[str]):
-            The client secret key for the client in Keycloak. If not provided, the value from the environment
-            variable KEYCLOAK_CLIENT_SECRET will be used.
-        verify (Optional[bool]):
-            Controls whether SSL certificates are verified for HTTPS requests. If set to False, SSL
-            verification is disabled. If set to a string, it should be the path to a CA_BUNDLE file or
-            a directory containing certificates of trusted CA.
-
-    Returns:
-        Union[int, Tuple[int, str]]:
-            If successful, a string containing the access token in the form of "{token_type} {access_token}".
-            Otherwise, a tuple containing a status code and an error message.
-
+        username: Keycloak username.
+        password: Keycloak password.
+    Kwargs: See get_keycloak_openid for remaining parameters.
     """
     logger.info("Making authentication header")
     credentials = login(
@@ -418,25 +314,18 @@ def make_auth_header(
         client_secret,
         verify,
     )
-    if type(credentials) == str:
+    if isinstance(credentials, str):
         logger.info("Authentication header created successfully")
         return {"Authorization": credentials}
-    else:
-        logger.error("Failed to create authentication header")
-        return credentials
+    logger.error("Failed to create authentication header")
+    return credentials
 
 
-def get_userinfo(token) -> dict:
-    """
-    Returns the user information from the access token.
+def get_userinfo(token: str) -> dict:
+    """Return the userinfo claims from Keycloak for the given access token.
 
     Args:
-        token: str
-            The access token of the user.
-
-    Returns:
-        dict:
-            The user information.
+        token: Raw access token string.
     """
     userinfo = get_keycloak_openid().userinfo(token)
     logger.debug(f"get_userinfo: Retrieved user info {userinfo}")
@@ -444,13 +333,7 @@ def get_userinfo(token) -> dict:
 
 
 def get_current_user() -> str:
-    """
-    Get the current logged in user.
-
-    Returns:
-        str:
-            The user ID.
-    """
+    """Return the Keycloak user ID (``sub``) for the current request token."""
     user_info = get_userinfo()
     if not user_info:
         logger.warning("get_current_user: No user info available")

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -1,4 +1,4 @@
-"""Pytest fixtures for regitering mock responses."""
+"""Pytest fixtures for registering mock responses."""
 
 import os
 
@@ -15,18 +15,41 @@ VARIABLES = dict(
     KEYCLOAK_VERIFY_HOST="True",
 )
 
+# Realistic Keycloak introspect payload — roles live under realm_access and
+# resource_access, not at the top level.
+INTROSPECT_RESPONSE = dict(
+    active=True,
+    realm_access={"roles": ["default-roles-myrealm", "app-user", "admin"]},
+    resource_access={
+        "testshield": {"roles": ["admin", "user"]},
+        "account": {"roles": ["manage-account", "view-profile"]},
+    },
+    scope="profile email client_roles",
+    preferred_username="admin",
+    sub="test-user-id",
+)
+
+INTROSPECT_NON_ADMIN = dict(
+    active=True,
+    realm_access={"roles": ["default-roles-myrealm", "app-user"]},
+    resource_access={
+        "testshield": {"roles": ["user"]},
+        "account": {"roles": ["manage-account", "view-profile"]},
+    },
+    scope="profile email client_roles",
+    preferred_username="user1",
+    sub="non-admin-user-id",
+)
+
+INTROSPECT_INACTIVE = dict(active=False)
+
 
 def register_mock(requests_mock: Mocker, var: dict = VARIABLES) -> None:
-    """
-    Register mock HTTP responses for a Keycloak server using the requests_mock library.
+    """Register mock HTTP responses for a Keycloak server.
 
     Args:
-    - requests_mock: An instance of the Mocker class from the requests_mock library.
-    - var: A dictionary containing environment variables used to configure the Keycloak server.
-      It must contain the following keys:
-      - KEYCLOAK_HOST: the URL of the Keycloak server (e.g., "http://example_keycloak.org/auth/").
-      - KEYCLOAK_REALM_NAME: the name of the Keycloak realm to use.
-      - KEYCLOAK_CLIENT_SECRET: the client secret for the Keycloak client.
+        requests_mock: requests_mock Mocker instance.
+        var: Environment variable overrides (defaults to VARIABLES).
     """
     os.environ.update(**var)
     realm_name = var["KEYCLOAK_REALM_NAME"]
@@ -47,20 +70,40 @@ def register_mock(requests_mock: Mocker, var: dict = VARIABLES) -> None:
         dict(
             path=f"realms/{realm_name}/protocol/openid-connect/token/introspect",
             method="post",
-            json=dict(
-                active=True,
-                roles=["admin"],
-                scope="profile email client_roles",
-            ),
+            json=INTROSPECT_RESPONSE,
         ),
         dict(
             path=f"realms/{realm_name}/protocol/openid-connect/userinfo",
             method="post",
             json=dict(
-                sub="123",
+                sub="test-user-id",
                 email_verified=False,
-                roles=["admin"],
                 preferred_username="admin",
+            ),
+        ),
+    ]
+    for route in responses:
+        path = var["KEYCLOAK_HOST"] + route["path"]
+        requests_mock.register_uri(route["method"], path, json=route["json"])
+
+
+def register_mock_non_admin(requests_mock: Mocker, var: dict = VARIABLES) -> None:
+    """Register mock responses for a non-admin user."""
+    os.environ.update(**var)
+    realm_name = var["KEYCLOAK_REALM_NAME"]
+    responses = [
+        dict(
+            path=f"realms/{realm_name}/protocol/openid-connect/token/introspect",
+            method="post",
+            json=INTROSPECT_NON_ADMIN,
+        ),
+        dict(
+            path=f"realms/{realm_name}/protocol/openid-connect/userinfo",
+            method="post",
+            json=dict(
+                sub="non-admin-user-id",
+                email_verified=False,
+                preferred_username="user1",
             ),
         ),
     ]

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,4 +1,4 @@
-"""Pytest fixture for testing shieldapi in fastapi """
+"""Pytest fixture for testing shieldapi in fastapi"""
 
 import re
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,27 +1,224 @@
-"""Pytest fixture for testing shieldapi in flask"""
+"""Tests for shieldapi Flask decorators."""
 
+import pytest
 from flask import Flask
 
-from shieldapi.frameworks.flask import login_required
+from shieldapi.frameworks.flask import (
+    admin_required,
+    has_scope,
+    login_required,
+    role_required,
+)
 
-from .mock import MESSAGE, register_mock
+from .mock import MESSAGE, register_mock, register_mock_non_admin
 
 app = Flask(__name__)
 
 
 @app.get("/login")
 @login_required
-def login():
-    """Arbitrary login route"""
+def login_view():
     return MESSAGE
 
 
-def test_flask(mock_introspect, requests_mock):
-    """Pytest for token verification through Keycloak-mock."""
+@app.get("/admin")
+@login_required
+@admin_required
+def admin_view():
+    return MESSAGE
+
+
+@app.get("/editor")
+@login_required
+@role_required("editor")
+def editor_view():
+    return MESSAGE
+
+
+@app.get("/scoped")
+@login_required
+@has_scope(["profile"])
+def scoped_view():
+    return MESSAGE
+
+
+@pytest.fixture
+def client():
+    return app.test_client()
+
+
+def test_login_required_valid_token(client, requests_mock):
+    register_mock(requests_mock)
+    response = client.get("/login", headers={"Authorization": "Bearer 123"})
+    assert response.status_code == 200
+    assert response.json == MESSAGE
+
+
+def test_login_required_no_token(client, requests_mock):
+    register_mock(requests_mock)
+    response = client.get("/login")
+    assert response.status_code == 401
+
+
+def test_login_required_invalid_token(client, requests_mock):
+    """Inactive token must be rejected with 401."""
+    register_mock(requests_mock)
+    # Override introspect to return inactive
+    import os
+
+    realm = os.environ["KEYCLOAK_REALM_NAME"]
+    host = os.environ["KEYCLOAK_HOST"]
+    requests_mock.post(
+        f"{host}realms/{realm}/protocol/openid-connect/token/introspect",
+        json={"active": False},
+    )
+    response = client.get("/login", headers={"Authorization": "Bearer expired"})
+    assert response.status_code == 401
+
+
+def test_admin_required_with_admin_role(client, requests_mock):
+    """Token with admin role in realm_access should pass."""
+    register_mock(requests_mock)
+    response = client.get("/admin", headers={"Authorization": "Bearer 123"})
+    assert response.status_code == 200
+    assert response.json == MESSAGE
+
+
+def test_admin_required_without_admin_role(client, requests_mock):
+    """Token without admin role should be rejected with 403."""
+    register_mock_non_admin(requests_mock)
+    response = client.get("/admin", headers={"Authorization": "Bearer 123"})
+    assert response.status_code == 403
+
+
+def test_admin_required_no_token(client, requests_mock):
+    register_mock(requests_mock)
+    response = client.get("/admin")
+    assert response.status_code == 401
+
+
+def test_role_required_with_matching_role(client, requests_mock):
+    """Token with the required role (client-level) should pass."""
+    import os
+
+    register_mock(requests_mock)
+    # The mock introspect grants resource_access.testshield.roles = ["admin", "user"]
+    # but not "editor". Override to add editor.
+    realm = os.environ["KEYCLOAK_REALM_NAME"]
+    host = os.environ["KEYCLOAK_HOST"]
+    requests_mock.post(
+        f"{host}realms/{realm}/protocol/openid-connect/token/introspect",
+        json={
+            "active": True,
+            "realm_access": {"roles": []},
+            "resource_access": {"testshield": {"roles": ["editor"]}},
+            "scope": "profile email",
+        },
+    )
+    response = client.get("/editor", headers={"Authorization": "Bearer 123"})
+    assert response.status_code == 200
+
+
+def test_role_required_without_matching_role(client, requests_mock):
+    """Token lacking the required role should be rejected with 403."""
+    register_mock_non_admin(requests_mock)
+    response = client.get("/editor", headers={"Authorization": "Bearer 123"})
+    assert response.status_code == 403
+
+
+def test_has_scope_with_scope_present(client, requests_mock):
+    register_mock(requests_mock)
+    response = client.get("/scoped", headers={"Authorization": "Bearer 123"})
+    assert response.status_code == 200
+
+
+def test_has_scope_missing_scope(client, requests_mock):
+    """Token without required scope should be rejected with 403."""
+    import os
+
+    register_mock(requests_mock)
+    realm = os.environ["KEYCLOAK_REALM_NAME"]
+    host = os.environ["KEYCLOAK_HOST"]
+    requests_mock.post(
+        f"{host}realms/{realm}/protocol/openid-connect/token/introspect",
+        json={"active": True, "scope": "email"},
+    )
+    response = client.get("/scoped", headers={"Authorization": "Bearer 123"})
+    assert response.status_code == 403
+
+
+def test_check_role_realm_access(requests_mock):
+    """check_role finds roles in realm_access.roles."""
+    from shieldapi.keycloak_utils import check_role
+
+    register_mock(requests_mock)
+    assert check_role("123", "admin") is True
+
+
+def test_check_role_resource_access(requests_mock):
+    """check_role finds roles in resource_access.<client>.roles."""
+    import os
+
+    from shieldapi.keycloak_utils import check_role
+
+    register_mock(requests_mock)
+    realm = os.environ["KEYCLOAK_REALM_NAME"]
+    host = os.environ["KEYCLOAK_HOST"]
+    requests_mock.post(
+        f"{host}realms/{realm}/protocol/openid-connect/token/introspect",
+        json={
+            "active": True,
+            "realm_access": {"roles": []},
+            "resource_access": {"my-client": {"roles": ["superuser"]}},
+        },
+    )
+    assert check_role("123", "superuser") is True
+
+
+def test_check_role_flat_roles_field(requests_mock):
+    """check_role also handles legacy flat roles field."""
+    import os
+
+    from shieldapi.keycloak_utils import check_role
+
+    register_mock(requests_mock)
+    realm = os.environ["KEYCLOAK_REALM_NAME"]
+    host = os.environ["KEYCLOAK_HOST"]
+    requests_mock.post(
+        f"{host}realms/{realm}/protocol/openid-connect/token/introspect",
+        json={"active": True, "roles": ["legacy-role"]},
+    )
+    assert check_role("123", "legacy-role") is True
+
+
+def test_check_role_absent(requests_mock):
+    """check_role returns False when the role is not present anywhere."""
+    from shieldapi.keycloak_utils import check_role
+
+    register_mock_non_admin(requests_mock)
+    assert check_role("123", "admin") is False
+
+
+def test_check_role_inactive_token(requests_mock):
+    """check_role returns False for an inactive token."""
+    import os
+
+    from shieldapi.keycloak_utils import check_role
+
+    register_mock(requests_mock)
+    realm = os.environ["KEYCLOAK_REALM_NAME"]
+    host = os.environ["KEYCLOAK_HOST"]
+    requests_mock.post(
+        f"{host}realms/{realm}/protocol/openid-connect/token/introspect",
+        json={"active": False},
+    )
+    assert check_role("123", "admin") is False
+
+
+def test_flask_keycloak_called_once(requests_mock):
+    """Verify exactly one Keycloak call is made per request."""
     register_mock(requests_mock)
     client = app.test_client()
-    headers = {"Authorization": "Bearer 123"}
-    response = client.get("login", headers=headers)  # calls keycloak-mock
+    client.get("/login", headers={"Authorization": "Bearer 123"})
     host_list = [resp.hostname for resp in requests_mock.request_history]
-    assert host_list.count("example_keycloak.org") == 1  # called 1x keycloak-mock
-    assert response.json == MESSAGE
+    assert host_list.count("example_keycloak.org") == 1


### PR DESCRIPTION
## Summary

- **Fix `check_role`**: was looking for a flat `roles` field in Keycloak's introspect response, which Keycloak never populates by default. Now correctly searches `realm_access.roles` and `resource_access.<client>.roles`, making `admin_required` and `role_required` actually work on standard deployments.
- **Fix `has_scope` and `check_useraccount_access`**: were calling `.json()` on the introspect result, which has been a plain dict since python-keycloak 2.x — silently broken for years.
- **Fix `login()` callers**: checked `len(token) == 2` (string-length) instead of `isinstance(token, tuple)` to detect failure returns.
- **Fix `has_scope` abort behaviour**: was returning `None` silently on scope failure instead of calling `abort(403)`, inconsistent with all other decorators.
- **Dependency hygiene**: `python_requires` raised to `>=3.9` (3.6 EOL Dec 2021); `python-keycloak` loosened to `>=4.0`; `flask` and `fastapi` moved to optional extras `[flask]`/`[fastapi]` so consumers only pull in the framework they use; `bumpver.current_version` corrected from `"v0.0.0"` to `"v2.2.0"`.
- **Test coverage**: mock updated to realistic Keycloak introspect format; new tests for all three `check_role` lookup paths, `admin_required`/`role_required` with and without the role, `has_scope`, and invalid-token rejection.
- **Tooling**: pre-commit hooks bumped to latest stable (pre-commit-hooks v6, black 26.5.1 via mirror, isort 8.0.1 — skipped the 9.0.0a3 alpha that autoupdate proposed).

## Release

After merging, tag `v2.2.0` to trigger the PyPI publish pipeline.

## Test plan

- [ ] CI passes (108 tests)
- [ ] Verify `admin_required` works end-to-end against a live Keycloak instance with a user that has `realm_access.roles: ["admin"]`
- [ ] Confirm `pip install shieldapi` (without extras) no longer forces Flask or FastAPI installation